### PR TITLE
Animated colors and scaling in toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,24 +86,12 @@
         min-width: 28;
         height: 28;
         text-align: center;
+        transition: all 0.25s linear;
       }
 
       .tool_icon:hover {
         cursor: pointer;
-      }
-
-      /* Only if feather replaced tools with svg: */
-      svg.tool_icon:hover {
-        /* Tool icons grow bigger on hover: */
-        min-width: 36;
-        height: 36;
-      }
-
-      /* Tools are div when offline: */
-      div.tool_icon:hover {
-        /* The size of the sidebar is based on the biggest element,
-            thus, use italic for feedback since it doesn't change width: */
-        font-style: italic;
+        transform: scale(1.3);
       }
 
       /* SVG styling:


### PR DESCRIPTION
A small 0.25 second animation to change colors and sizes of icons
and text in toolbox looks good. This also works well for both
icons as well as text, so I can remove the old css which treated
them separately.